### PR TITLE
bitfields item example

### DIFF
--- a/examples/item-bitfields-landsat.json
+++ b/examples/item-bitfields-landsat.json
@@ -1,0 +1,1222 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "LC08_L2SP_047027_20201204_02_T1",
+    "properties": {
+        "platform": "landsat-8",
+        "instruments": [
+            "oli",
+            "tirs"
+        ],
+        "created": "2022-03-18T14:15:28.445062Z",
+        "gsd": 30,
+        "description": "Landsat Collection 2 Level-2",
+        "eo:cloud_cover": 1.55,
+        "view:off_nadir": 0,
+        "view:sun_elevation": 18.80722985,
+        "view:sun_azimuth": 164.91405951,
+        "proj:epsg": 32610,
+        "proj:shape": [
+            7971,
+            7861
+        ],
+        "proj:transform": [
+            30.0,
+            0.0,
+            353685.0,
+            0.0,
+            -30.0,
+            5374215.0
+        ],
+        "landsat:cloud_cover_land": 1.9,
+        "landsat:wrs_type": "2",
+        "landsat:wrs_path": "047",
+        "landsat:wrs_row": "027",
+        "landsat:collection_category": "T1",
+        "landsat:collection_number": "02",
+        "landsat:correction": "L2SP",
+        "landsat:scene_id": "LC80470272020339LGN00",
+        "sci:doi": "10.5066/P9OGBGM6",
+        "datetime": "2020-12-04T19:02:11.194486Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -124.27384594041735,
+                    48.508330109565485
+                ],
+                [
+                    -121.83965465293758,
+                    48.078217267779486
+                ],
+                [
+                    -122.53780648794415,
+                    46.376775468741904
+                ],
+                [
+                    -124.89627102658746,
+                    46.80206928347854
+                ],
+                [
+                    -124.27384594041735,
+                    48.508330109565485
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5066/P9OGBGM6",
+            "title": "Landsat 8-9 OLI/TIRS Collection 2 Level-2"
+        },
+        {
+            "rel": "via",
+            "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l2-sr/items/LC08_L2SP_047027_20201204_20210313_02_T1_SR",
+            "type": "application/json",
+            "title": "USGS STAC Item"
+        },
+        {
+            "rel": "via",
+            "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l2-st/items/LC08_L2SP_047027_20201204_20210313_02_T1_ST",
+            "type": "application/json",
+            "title": "USGS STAC Item"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_thumb_small.jpeg",
+            "type": "image/jpeg",
+            "title": "Thumbnail image",
+            "roles": [
+                "thumbnail"
+            ]
+        },
+        "reduced_resolution_browse": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_thumb_large.jpeg",
+            "type": "image/jpeg",
+            "title": "Reduced resolution browse image",
+            "roles": [
+                "overview"
+            ]
+        },
+        "mtl.json": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_MTL.json",
+            "type": "application/json",
+            "title": "Product Metadata File (json)",
+            "description": "Collection 2 Level-2 Product Metadata File (json)",
+            "roles": [
+                "metadata"
+            ]
+        },
+        "mtl.txt": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_MTL.txt",
+            "type": "text/plain",
+            "title": "Product Metadata File (txt)",
+            "description": "Collection 2 Level-2 Product Metadata File (txt)",
+            "roles": [
+                "metadata"
+            ]
+        },
+        "mtl.xml": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_MTL.xml",
+            "type": "application/xml",
+            "title": "Product Metadata File (xml)",
+            "description": "Collection 2 Level-2 Product Metadata File (xml)",
+            "roles": [
+                "metadata"
+            ]
+        },
+        "ang": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ANG.txt",
+            "type": "text/plain",
+            "title": "Angle Coefficients File",
+            "description": "Collection 2 Level-1 Angle Coefficients File",
+            "roles": [
+                "metadata"
+            ]
+        },
+        "qa_pixel": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_QA_PIXEL.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Pixel Quality Assessment Band",
+            "description": "Collection 2 Level-1 Pixel Quality Assessment Band (QA_PIXEL)",
+            "raster:bands": [
+                {
+                    "nodata": 1,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "unit": "bit index",
+                    "classification:bitfields": [
+                        {
+                            "name": "fill",
+                            "description": "Corresponding pixels in L1 image bands are fill",
+                            "offset": 0,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_fill",
+                                    "description": "L1 image band pixels are not fill",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "fill",
+                                    "description": "L1 image band pixels are fill",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "dilated",
+                            "description": "Dilated cloud",
+                            "offset": 1,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_dilated",
+                                    "description": "Cloud is not dilated or no cloud",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "dilated",
+                                    "description": "Cloud dilation",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cirrus",
+                            "description": "Cirrus mask",
+                            "offset": 2,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_cirrus",
+                                    "description": "No confidence level set or low confidence cirrus",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "cirrus",
+                                    "description": "High confidence cirrus",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cloud",
+                            "description": "Cloud mask",
+                            "offset": 3,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_cloud",
+                                    "description": "Cloud confidence is not high",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "cloud",
+                                    "description": "High confidence cloud",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "shadow",
+                            "description": "Cloud shadow mask",
+                            "offset": 4,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_shadow",
+                                    "description": "Cloud shadow confidence is not high",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "shadow",
+                                    "description": "High confidence cloud shadow",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "snow",
+                            "description": "Snow/Ice mask",
+                            "offset": 5,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_snow",
+                                    "description": "Snow/Ice confidence is not high",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "snow",
+                                    "description": "High confidence snow cover",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "clear",
+                            "description": "Cloud or dilated cloud bits set",
+                            "offset": 6,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_clear",
+                                    "description": "Cloud or dilated cloud bits are set",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "clear",
+                                    "description": "Cloud and dilated cloud bits are not set",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "water",
+                            "description": "Water mask",
+                            "offset": 7,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_water",
+                                    "description": "Land or cloud",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "water",
+                                    "description": "Water",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cloud_confidence",
+                            "description": "Cloud confidence levels",
+                            "offset": 8,
+                            "length": 2,
+                            "classes": [
+                                {
+                                    "name": "not_set",
+                                    "description": "No confidence level set",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "low",
+                                    "description": "Low confidence cloud",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "medium",
+                                    "description": "Medium confidence cloud",
+                                    "value": 2
+                                },
+                                {
+                                    "name": "high",
+                                    "description": "High confidence cloud",
+                                    "value": 3
+                                }
+                            ]
+                        },
+                        {
+                            "name": "shadow_confidence",
+                            "description": "Cloud shadow confidence levels",
+                            "offset": 10,
+                            "length": 2,
+                            "classes": [
+                                {
+                                    "name": "not_set",
+                                    "description": "No confidence level set",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "low",
+                                    "description": "Low confidence cloud shadow",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "reserved",
+                                    "description": "Reserved - value not used",
+                                    "value": 2
+                                },
+                                {
+                                    "name": "high",
+                                    "description": "High confidence cloud shadow",
+                                    "value": 3
+                                }
+                            ]
+                        },
+                        {
+                            "name": "snow_confidence",
+                            "description": "Snow/Ice confidence levels",
+                            "offset": 12,
+                            "length": 2,
+                            "classes": [
+                                {
+                                    "name": "not_set",
+                                    "description": "No confidence level set",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "low",
+                                    "description": "Low confidence snow/ice",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "reserved",
+                                    "description": "Reserved - value not used",
+                                    "value": 2
+                                },
+                                {
+                                    "name": "high",
+                                    "description": "High confidence snow/ice",
+                                    "value": 3
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cirrus_confidence",
+                            "description": "Cirrus confidence levels",
+                            "offset": 14,
+                            "length": 2,
+                            "classes": [
+                                {
+                                    "name": "not_set",
+                                    "description": "No confidence level set",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "low",
+                                    "description": "Low confidence cirrus",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "reserved",
+                                    "description": "Reserved - value not used",
+                                    "value": 2
+                                },
+                                {
+                                    "name": "high",
+                                    "description": "High confidence cirrus",
+                                    "value": 3
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "roles": [
+                "cloud",
+                "cloud-shadow",
+                "snow-ice",
+                "water-mask"
+            ]
+        },
+        "qa_radsat": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_QA_RADSAT.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Radiometric Saturation and Terrain Occlusion Quality Assessment Band",
+            "description": "Collection 2 Level-1 Radiometric Saturation and Terrain Occlusion Quality Assessment Band (QA_RADSAT)",
+            "raster:bands": [
+                {
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "unit": "bit index",
+                    "classification:bitfields": [
+                        {
+                            "name": "band1",
+                            "description": "Band 1 radiometric saturation",
+                            "offset": 0,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 1 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 1 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "band2",
+                            "description": "Band 2 radiometric saturation",
+                            "offset": 1,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 2 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 2 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "band3",
+                            "description": "Band 3 radiometric saturation",
+                            "offset": 2,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 3 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 3 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "band4",
+                            "description": "Band 4 radiometric saturation",
+                            "offset": 3,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 4 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 4 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "band5",
+                            "description": "Band 5 radiometric saturation",
+                            "offset": 4,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 5 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 5 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "band6",
+                            "description": "Band 6 radiometric saturation",
+                            "offset": 5,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 6 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 6 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "band7",
+                            "description": "Band 7 radiometric saturation",
+                            "offset": 6,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 7 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 7 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 7,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "band9",
+                            "description": "Band 9 radiometric saturation",
+                            "offset": 8,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_saturated",
+                                    "description": "Band 9 is not saturated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "saturated",
+                                    "description": "Band 9 is saturated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 9,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 10,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "occlusion",
+                            "description": "Terrain not visible from sensor due to intervening terrain",
+                            "offset": 11,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_occluded",
+                                    "description": "Terrain is not occluded",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "occluded",
+                                    "description": "Terrain is occluded",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 12,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 13,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 14,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 15,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "roles": [
+                "saturation"
+            ]
+        },
+        "coastal": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_B1.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Coastal/Aerosol Band",
+            "description": "Collection 2 Level-2 Coastal/Aerosol Band (SR_B1) Surface Reflectance",
+            "eo:bands": [
+                {
+                    "name": "OLI_B1",
+                    "common_name": "coastal",
+                    "description": "Coastal/Aerosol",
+                    "center_wavelength": 0.44,
+                    "full_width_half_max": 0.02
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "scale": 2.75e-05,
+                    "offset": -0.2
+                }
+            ],
+            "roles": [
+                "data",
+                "reflectance"
+            ]
+        },
+        "blue": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_B2.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Blue Band",
+            "description": "Collection 2 Level-2 Blue Band (SR_B2) Surface Reflectance",
+            "eo:bands": [
+                {
+                    "name": "OLI_B2",
+                    "common_name": "blue",
+                    "description": "Visible blue",
+                    "center_wavelength": 0.48,
+                    "full_width_half_max": 0.06
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "scale": 2.75e-05,
+                    "offset": -0.2
+                }
+            ],
+            "roles": [
+                "data",
+                "reflectance"
+            ]
+        },
+        "green": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_B3.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Green Band",
+            "description": "Collection 2 Level-2 Green Band (SR_B3) Surface Reflectance",
+            "eo:bands": [
+                {
+                    "name": "OLI_B3",
+                    "common_name": "green",
+                    "description": "Visible green",
+                    "center_wavelength": 0.56,
+                    "full_width_half_max": 0.06
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "scale": 2.75e-05,
+                    "offset": -0.2
+                }
+            ],
+            "roles": [
+                "data",
+                "reflectance"
+            ]
+        },
+        "red": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_B4.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Red Band",
+            "description": "Collection 2 Level-2 Red Band (SR_B4) Surface Reflectance",
+            "eo:bands": [
+                {
+                    "name": "OLI_B4",
+                    "common_name": "red",
+                    "description": "Visible red",
+                    "center_wavelength": 0.65,
+                    "full_width_half_max": 0.04
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "scale": 2.75e-05,
+                    "offset": -0.2
+                }
+            ],
+            "roles": [
+                "data",
+                "reflectance"
+            ]
+        },
+        "nir08": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_B5.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Near Infrared Band 0.8",
+            "description": "Collection 2 Level-2 Near Infrared Band 0.8 (SR_B5) Surface Reflectance",
+            "eo:bands": [
+                {
+                    "name": "OLI_B5",
+                    "common_name": "nir08",
+                    "description": "Near infrared",
+                    "center_wavelength": 0.87,
+                    "full_width_half_max": 0.03
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "scale": 2.75e-05,
+                    "offset": -0.2
+                }
+            ],
+            "roles": [
+                "data",
+                "reflectance"
+            ]
+        },
+        "swir16": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_B6.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Short-wave Infrared Band 1.6",
+            "description": "Collection 2 Level-2 Short-wave Infrared Band 1.6 (SR_B6) Surface Reflectance",
+            "eo:bands": [
+                {
+                    "name": "OLI_B6",
+                    "common_name": "swir16",
+                    "description": "Short-wave infrared",
+                    "center_wavelength": 1.61,
+                    "full_width_half_max": 0.09
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "scale": 2.75e-05,
+                    "offset": -0.2
+                }
+            ],
+            "roles": [
+                "data",
+                "reflectance"
+            ]
+        },
+        "swir22": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_B7.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Short-wave Infrared Band 2.2",
+            "description": "Collection 2 Level-2 Short-wave Infrared Band 2.2 (SR_B7) Surface Reflectance",
+            "eo:bands": [
+                {
+                    "name": "OLI_B7",
+                    "common_name": "swir22",
+                    "description": "Short-wave infrared",
+                    "center_wavelength": 2.2,
+                    "full_width_half_max": 0.19
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "scale": 2.75e-05,
+                    "offset": -0.2
+                }
+            ],
+            "roles": [
+                "data",
+                "reflectance"
+            ]
+        },
+        "qa_aerosol": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_SR_QA_AEROSOL.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Aerosol Quality Assessment Band",
+            "description": "Collection 2 Level-2 Aerosol Quality Assessment Band (SR_QA_AEROSOL) Surface Reflectance Product",
+            "raster:bands": [
+                {
+                    "nodata": 1,
+                    "data_type": "uint8",
+                    "spatial_resolution": 30,
+                    "unit": "bit index",
+                    "classification:bitfields": [
+                        {
+                            "name": "fill",
+                            "description": "Corresponding pixels in L1 image bands are fill",
+                            "offset": 0,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_fill",
+                                    "description": "L1 image band pixels are not fill",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "fill",
+                                    "description": "L1 image band pixels are fill",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "retrieval",
+                            "description": "Valid aerosol retrieval",
+                            "offset": 1,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_valid",
+                                    "description": "Aerosol retrieval is not valid",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "valid",
+                                    "description": "Aerosol retrieval is valid",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "water",
+                            "description": "Water mask",
+                            "offset": 2,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_water",
+                                    "description": "Not water",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "water",
+                                    "description": "Water",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 3,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "unused",
+                            "description": "Unused bit",
+                            "offset": 4,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "unused",
+                                    "description": "Unused bit",
+                                    "value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "name": "interpolated",
+                            "description": "Aerosol is interpolated",
+                            "offset": 5,
+                            "length": 1,
+                            "classes": [
+                                {
+                                    "name": "not_interpolated",
+                                    "description": "Aerosol is not interpolated",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "interpolated",
+                                    "description": "Aerosol is interpolated",
+                                    "value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "level",
+                            "description": "Aerosol level",
+                            "offset": 6,
+                            "length": 2,
+                            "classes": [
+                                {
+                                    "name": "climatology",
+                                    "description": "No aerosol correction applied",
+                                    "value": 0
+                                },
+                                {
+                                    "name": "low",
+                                    "description": "Low aerosol level",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "medium",
+                                    "description": "Medium aerosol level",
+                                    "value": 2
+                                },
+                                {
+                                    "name": "high",
+                                    "description": "High aerosol level",
+                                    "value": 3
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "roles": [
+                "data-mask",
+                "water-mask"
+            ]
+        },
+        "lwir11": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_B10.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Surface Temperature Band",
+            "description": "Collection 2 Level-2 Thermal Infrared Band (ST_B10) Surface Temperature",
+            "eo:bands": [
+                {
+                    "name": "TIRS_B10",
+                    "common_name": "lwir11",
+                    "description": "Long-wave infrared",
+                    "center_wavelength": 10.9,
+                    "full_width_half_max": 0.59
+                }
+            ],
+            "raster:bands": [
+                {
+                    "nodata": 0,
+                    "data_type": "uint16",
+                    "spatial_resolution": 30,
+                    "unit": "kelvin",
+                    "scale": 0.00341802,
+                    "offset": 149.0
+                }
+            ],
+            "gsd": 100,
+            "roles": [
+                "data",
+                "temperature"
+            ]
+        },
+        "atran": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_ATRAN.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Atmospheric Transmittance Band",
+            "description": "Collection 2 Level-2 Atmospheric Transmittance Band (ST_ATRAN) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "scale": 0.0001
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "cdist": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_CDIST.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Cloud Distance Band",
+            "description": "Collection 2 Level-2 Cloud Distance Band (ST_CDIST) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "unit": "kilometer",
+                    "scale": 0.01
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "drad": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_DRAD.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Downwelled Radiance Band",
+            "description": "Collection 2 Level-2 Downwelled Radiance Band (ST_DRAD) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "unit": "watt/steradian/square_meter/micrometer",
+                    "scale": 0.001
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "urad": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_URAD.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Upwelled Radiance Band",
+            "description": "Collection 2 Level-2 Upwelled Radiance Band (ST_URAD) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "unit": "watt/steradian/square_meter/micrometer",
+                    "scale": 0.001
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "trad": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_TRAD.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Thermal Radiance Band",
+            "description": "Collection 2 Level-2 Thermal Radiance Band (ST_TRAD) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "unit": "watt/steradian/square_meter/micrometer",
+                    "scale": 0.001
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "emis": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_EMIS.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Emissivity Band",
+            "description": "Collection 2 Level-2 Emissivity Band (ST_EMIS) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "unit": "emissivity coefficient",
+                    "scale": 0.0001
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "emsd": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_EMSD.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Emissivity Standard Deviation Band",
+            "description": "Collection 2 Level-2 Emissivity Standard Deviation Band (ST_EMSD) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "unit": "emissivity coefficient",
+                    "scale": 0.0001
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "qa": {
+            "href": "LC08_L2SP_047027_20201204_20210313_02_T1_ST_QA.TIF",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Surface Temperature Quality Assessment Band",
+            "description": "Collection 2 Level-2 Quality Assessment Band (ST_QA) Surface Temperature Product",
+            "raster:bands": [
+                {
+                    "nodata": -9999,
+                    "data_type": "int16",
+                    "spatial_resolution": 30,
+                    "unit": "kelvin",
+                    "scale": 0.01
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -124.98085491310867,
+        46.35352512466258,
+        -121.78788697796408,
+        48.51466487533742
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://landsat.usgs.gov/stac/landsat-extension/v1.1.1/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/classification/v0.0.1/schema.json"
+    ],
+    "collection": "landsat-c2-l2"
+}


### PR DESCRIPTION
Landsat Item example with `classification:bitfields` in `raster:bands`.