### PR TITLE
Add name regex and title to class object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added 
+### Added
 
 - `nodata` to `classification:classes`
+- Regular expression to validate `name` is machine-readable
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ For a real world example, see [Landsat 8's Quality raster](https://www.usgs.gov/
 | ----------- | ---------- | -------------------------------------------------------------------------------------------------------------------- |
 | value       | `integer`  | **REQUIRED.** Value of the class                                                                                     |
 | description | `string`   | Description of the class. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| name        | `string`   | **REQUIRED.** Short name of the class for machine readability                                                        |
+| name        | `string`   | **REQUIRED.** Short name of the class for machine readability. Must consist only of letters, numbers, `-`, and `_` characters.                                                        |
+| title  | `string` | Human-readable name for use in, e.g., a map legend. |
 | color_hint  | RGB string | suggested color for rendering (Hex RGB code in upper-case without leading #)                                         |
 | nodata      | `boolean`  | If set to `true` classifies a value as a no-data value, defaults to `false`                                          |
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For a real world example, see [Landsat 8's Quality raster](https://www.usgs.gov/
 | value       | `integer`  | **REQUIRED.** Value of the class                                                                                     |
 | description | `string`   | Description of the class. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | name        | `string`   | **REQUIRED.** Short name of the class for machine readability. Must consist only of letters, numbers, `-`, and `_` characters.                                                        |
-| title  | `string` | Human-readable name for use in, e.g., a map legend. |
+| title       | `string` | Human-readable name for use in, e.g., a map legend. |
 | color_hint  | RGB string | suggested color for rendering (Hex RGB code in upper-case without leading #)                                         |
 | nodata      | `boolean`  | If set to `true` classifies a value as a no-data value, defaults to `false`                                          |
 

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -166,6 +166,10 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string",
+                    "pattern": "^[0-9A-Za-z-_]+$"
+                },
+                "title": {
                     "type": "string"
                 },
                 "color_hint": {


### PR DESCRIPTION
Adds a name regex (`^[0-9A-Za-z-_]+$`) and an optional `title` field to the class object. This helps solidify what "machine readable" means for the name, and provides a way for a data provider to give a human-readable title for, e.g., map legends.

## Related issues

- Closes #37 